### PR TITLE
Fix pendulum install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ckcc-protocol>=1.0.1
 pynacl==1.3.0
 aiohttp_session
 click
-pendulum
+pendulum==2.0.3
 pyyaml
 Pillow
 pytest


### PR DESCRIPTION
My original installation failed with with this error:
https://github.com/sdispater/pendulum/issues/457#issue-592203726

In case others face the same issue:
To install ckbunker, it was necessary for me to specify the version of pendulum as 2.0.3

Fix came from here:
https://github.com/sdispater/pendulum/issues/457#issuecomment-607567871