### PR TITLE
Added install requirements and packages=[]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,11 @@ setup(
         'aiohttp',
         'aiohttp-jinja2',
         'ckcc-protocol>=1.3.2',
+        'pyyaml',
+        'pynacl==1.3.0',
+        'pendulum==2.0.3',
+        'aiohttp_session',
+        'requests[socks]',
     ],
     entry_points='''
         [console_scripts]
@@ -38,5 +43,5 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: MacOS :: MacOS X',
     ],
+    packages=[],
 )
-


### PR DESCRIPTION
In version 61 of setuptools, there is a [breaking change](https://setuptools.pypa.io/en/latest/history.html#v61-0-0) that introduced auto discovery for packages if no `packages` or `py_modules` is explicitly specified.

This breaks the command `pip install --editable .` as it thinks random folders are packages:

```
❯ pip install --editable .
Obtaining (...)ckbunker
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [14 lines of output]
      error: Multiple top-level packages discovered in a flat-layout: ['ENV', 'data', 'static', 'templates'].

      To avoid accidental inclusion of unwanted files or directories,
      setuptools will not proceed with this build.

      If you are trying to create a single distribution with multiple packages
      on purpose, you should not rely on automatic discovery.
      Instead, consider the following options:

      1. set up custom discovery (`find` directive with `include` or `exclude`)
      2. use a `src-layout`
      3. explicitly set `py_modules` or `packages` with a list of names

      To find more information, look for "package discovery" on setuptools docs.
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

To fix this, I added `packages=[],` and list all the packages used under `install_requirements` in setup.py.