### PR TITLE
escape needs to be imported from markupsafe for newer jinja2 versions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -18,7 +18,7 @@ Then:
 You will need:
 
 - this code (see above)
-- a Mk3 Coldcard connected via USB, running
+- a Mk3 or Mk4 Coldcard connected via USB, running
   [firmware version 3.1.0 or later](https://coldcardwallet.com/docs/upgrade)
 - `tord` (Tor program)
 - an Internet connection

--- a/webapp.py
+++ b/webapp.py
@@ -21,9 +21,9 @@ from hashlib import sha256
 from chain import broadcast_txn
 from version import VERSION
 try:
-    from jinja2 import Markup
+    from jinja2 import Markup, escape
 except ImportError:
-    from markupsafe import Markup
+    from markupsafe import Markup, escape
 import policy
 
 from ckcc.constants import USER_AUTH_TOTP, USER_AUTH_HMAC, USER_AUTH_SHOW_QR, MAX_USERNAME_LEN
@@ -326,7 +326,7 @@ async def rx_handler(ses, ws, orig_request):
 
         if failed:
             # standard error response
-            await tx_resp(show_modal=True, html=jinja2.escape(msg), selector='.js-api-fail')
+            await tx_resp(show_modal=True, html=escape(msg), selector='.js-api-fail')
 
 async def push_status_updates_handler(ws):
     # block for a bit, and then send display updates (and all other system status changes)


### PR DESCRIPTION
* same as with markup
* user reported https://github.com/Coldcard/ckbunker/issues/21