### PR TITLE
python 3.12 `random.randint` requires integers

### DIFF
--- a/make_captcha.py
+++ b/make_captcha.py
@@ -92,7 +92,7 @@ class MegaGifCaptcha(CaptchaMaker):
                 #ch = ''.join(self.rng.sample(TOKEN_CHARS, 1)).upper()
                 ch = ''.join(sample(charset, 1)).upper()
                 x = randint(-dx, w)
-                y = ans_y + randint(-dy*3/4, dy*3/4)
+                y = ans_y + randint(int(-dy*3/4), int(dy*3/4))
                 dr.text( (x,y), ch, fill=foreground, font=fn)
 
             frames.append(im)


### PR DESCRIPTION
* changed in py312: _Automatic conversion of non-integer types is no longer supported. Calls such as randrange(10.0) and randrange(Fraction(10, 1)) now raise a TypeError_ https://docs.python.org/3/library/random.html#random.randrange

* fails at captcha generation:
```
Traceback (most recent call last):
  File "/home/scg/PycharmProjects/ckbunker/ENV/lib/python3.12/site-packages/aiohttp/web_protocol.py", line 456, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/scg/PycharmProjects/ckbunker/ENV/lib/python3.12/site-packages/aiohttp/web_app.py", line 537, in _handle
    resp = await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/scg/PycharmProjects/ckbunker/ENV/lib/python3.12/site-packages/aiohttp/web_middlewares.py", line 114, in impl
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/scg/PycharmProjects/ckbunker/ENV/lib/python3.12/site-packages/aiohttp_session/__init__.py", line 199, in factory
    response = await handler(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/scg/PycharmProjects/ckbunker/webapp.py", line 799, in auth_everything
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/scg/PycharmProjects/ckbunker/webapp.py", line 273, in captcha_image
    itype, data = MegaGifCaptcha(seed=code).draw(code, foreground='#444')
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/scg/PycharmProjects/ckbunker/make_captcha.py", line 95, in draw
    y = ans_y + randint(-dy*3/4, dy*3/4)
                ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/random.py", line 336, in randint
    return self.randrange(a, b+1)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/random.py", line 301, in randrange
    istart = _index(start)
             ^^^^^^^^^^^^^
TypeError: 'float' object cannot be interpreted as an integer
```