### PR TITLE
make the catcha appear in python 3.11

### DIFF
--- a/make_captcha.py
+++ b/make_captcha.py
@@ -90,7 +90,7 @@ class MegaGifCaptcha(CaptchaMaker):
 
             for k in range(int(w * 1.5/dx)):
                 #ch = ''.join(self.rng.sample(TOKEN_CHARS, 1)).upper()
-                ch = ''.join(sample(charset, 1)).upper()
+                ch = ''.join(sample(list(charset), 1)).upper()
                 x = randint(-dx, w)
                 y = ans_y + randint(-dy*3/4, dy*3/4)
                 dr.text( (x,y), ch, fill=foreground, font=fn)


### PR DESCRIPTION
On Python 3.11 the captcha doesn't appear anymore:

![Screenshot 2023-05-06 at 08-46-06 Login](https://user-images.githubusercontent.com/5938863/236610983-46a63fc3-a1eb-48e7-8b96-85d01dd9301d.png)

As this error happens:
```
500 Internal Server Error
Traceback:

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/aiohttp/web_protocol.py", line 433, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/aiohttp/web_app.py", line 504, in _handle
    resp = await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/aiohttp/web_middlewares.py", line 117, in impl
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/aiohttp_session/__init__.py", line 199, in factory
    response = await handler(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/me/Projects/ckbunker/webapp.py", line 799, in auth_everything
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/me/Projects/ckbunker/webapp.py", line 273, in captcha_image
    itype, data = MegaGifCaptcha(seed=code).draw(code, foreground='#444')
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/me/Projects/ckbunker/make_captcha.py", line 93, in draw
    ch = ''.join(sample(charset, 1)).upper()
                 ^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/random.py", line 436, in sample
    raise TypeError("Population must be a sequence.  "
TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
```

Then, I found in the [changelog](https://docs.python.org/3/whatsnew/3.11.html):
```
The population parameter of [random.sample()](https://docs.python.org/3/library/random.html#random.sample) 
must be a sequence, and automatic conversion of [set](https://docs.python.org/3/library/stdtypes.html#set)s
to [list] (https://docs.python.org/3/library/stdtypes.html#list)s is no longer supported.
```

So I changed `ch = ''.join(sample(charset, 1)).upper()` to `ch = ''.join(sample(list(charset), 1)).upper()` and now the captcha shows again:

![Screenshot 2023-05-06 at 08-52-16 Login](https://user-images.githubusercontent.com/5938863/236611151-0ca7852f-052c-453d-8f9b-4f8e0ea83b99.png)
